### PR TITLE
chore(gitignore): ignore _docs/ (internal docs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work.sum
 .env
 
 .idea/
+
+# Internal docs
+_docs/


### PR DESCRIPTION
Avoid versioning internal/generated docs; reduces PR noise. No build/runtime impact.